### PR TITLE
Upgrade macOS/Travis default image to xcode6.4

### DIFF
--- a/cfep-02.md
+++ b/cfep-02.md
@@ -50,6 +50,14 @@ osx_image: xcode6.4
 
 * [@jakirkham on implications][impl]
 * [Travis image support policy][travis]
+* [Travis CI changes default to Mac OS 10.11 XCode 7.3]( https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/ )
+* [Travis CI image restructuring]( https://blog.travis-ci.com/2016-09-15-new-default-osx-image-coming/ )
+* [Currently available Travis CI OS X images]( https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version )
+* [Details on Mac OS 10.9 XCode 6.1]( https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.1 ) supports 10.9 and 10.10
+* [Details on Mac OS 10.10 XCode 6.4]( https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4 ) supports 10.9 and 10.10
+* [Setting OS X deployment target](
+https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
+)
 
 [impl]: https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392
 [travis]: https://github.com/travis-ci/travis-ci/issues/6765#issuecomment-256703076

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -35,11 +35,11 @@ Upgrade the default Travis image to `xcode6.4`.
 ## Rationale
 
 *   The current default image (`beta-xcode6.1`) is deprecated
-    and will cease to be [supported/provided by Travis][travis],
+    and will cease to be [supported/provided by Travis][travis-retire],
     so this change will have to happen at some point anyway.
 
     It will go away on January 21, 2017 according to the stated
-    plan in the linked comment. At that point, all packages
+    plan in the linked post. At that point, all packages
     specifying the previous image (`beta-xcode6.1`) will
     implicitly be bumped to Travis's default image, which will result
     in packages that do not meet conda-forge's promise of OS compatibility
@@ -73,10 +73,12 @@ Upgrade the default Travis image to `xcode6.4`.
 https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
 )
 * [Apple C++ ABI Compatibility][cxxabi]
+* [Travis CI: Retiring some OS/X images][travis-retire]
 
 [impl]: https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392
 [travis]: https://github.com/travis-ci/travis-ci/issues/6765#issuecomment-256703076
 [cxxabi]: https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/CppRuntimeEnv/Articles/CPPROverview.html
+[travis-retire]: https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/
 
 ## Copyright
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -5,7 +5,7 @@
 <tr><td> Author(s) </td><td> Andreas Kloeckner &lt;inform@tiker.net&gt;</td></tr>
 <tr><td> Created </td><td> Nov 8, 2016</td></tr>
 <tr><td> Updated </td><td> Nov 8, 2016</td></tr>
-<tr><td> Discussion </td><td> TBD </td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6 </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -30,7 +30,7 @@ osx_image: xcode6.4
 ## Rationale
 
 *   The current default image (`beta-xcode6.1`) is deprecated
-    and will cease to be supported/provided by Travis [@jakirkham: citation needed],
+    and will cease to be [supported/provided by Travis][travis],
     so this change will have to happen at some point anyway.
 
 *   We won't be able to compile [clang

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -1,10 +1,10 @@
 
 <table>
 <tr><td> Title </td><td> Upgrade default macOS Travis image to `xcode6.4` </td>
-<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Andreas Kloeckner &lt;inform@tiker.net&gt;</td></tr>
 <tr><td> Created </td><td> Nov 8, 2016</td></tr>
-<tr><td> Updated </td><td> Nov 8, 2016</td></tr>
+<tr><td> Updated </td><td> Jan 8, 2016</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6 </td></tr>
 <tr><td> Implementation </td><td> (listed below) </td></tr>
 </table>

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -51,8 +51,8 @@ osx_image: xcode6.4
 * [@jakirkham on implications][impl]
 * [Travis image support policy][travis]
 
-[impl](https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392)
-[travis][https://github.com/travis-ci/travis-ci/issues/6765#issuecomment-256703076]
+[impl]: https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392
+[travis]: https://github.com/travis-ci/travis-ci/issues/6765#issuecomment-256703076
 
 ## Copyright
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -27,6 +27,11 @@ Upgrade the default Travis image to `xcode6.4`.
 *   Suggest that all new packages include the `toolchain` so that
     the macOS 10.9 deployment target can be set.
 
+    Ideally, the correct setting of the deployment target would be verified by
+    CI, but the implementation of such a measure, while
+    [technically possible](http://stackoverflow.com/a/17148833),
+    is not part of this proposal.
+
 ## Rationale
 
 *   The current default image (`beta-xcode6.1`) is deprecated
@@ -34,7 +39,11 @@ Upgrade the default Travis image to `xcode6.4`.
     so this change will have to happen at some point anyway.
 
     It will go away on January 21, 2017 according to the stated
-    plan in the linked comment.
+    plan in the linked comment. At that point, all packages
+    specifying the previous image (`beta-xcode6.1`) will
+    implicitly be bumped to Travis's default image, which will result
+    in packages that do not meet conda-forge's promise of OS compatibility
+    back to 10.9.
 
 *   Multiple packages need this to move forward:
 
@@ -48,8 +57,8 @@ Upgrade the default Travis image to `xcode6.4`.
     It would need to be forced to 10.9 (the lowest supported one
     for that image) by hand.
 
-*   Even with this change, this would implicitly drop support for
-    macOS 10.7 and 10.8.
+*   The proposed change will not drop support for any previously
+    supported OS versions.
 
 ## References
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -1,0 +1,55 @@
+
+<table>
+<tr><td> Title </td><td> Upgrade default macOS Travis image to `xcode6.4` </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Andreas Kloeckner &lt;inform@tiker.net&gt;</td></tr>
+<tr><td> Created </td><td> Nov 8, 2016</td></tr>
+<tr><td> Updated </td><td> Nov 8, 2016</td></tr>
+<tr><td> Discussion </td><td> TBD </td></tr>
+<tr><td> Implementation </td><td> NA </td></tr>
+</table>
+
+## Abstract
+
+Upgrade the default Travis image to `xcode6.4`.
+
+## Implementation
+
+This is a one-line change to `.travis.yml`
+
+```
+osx_image: xcode6.4
+```
+
+*   Adapt `conda smithy` so that it applies that edit on rerender
+*   Apply the change in the `staged-recipes` master branch.
+*   Rebuild all packages with this? (TBD? Opinions?)
+*   Suggest that all packages include the `toolchain` so that
+    the macOS 10.9 deployment target can be set.
+
+## Rationale
+
+*   The current default image (`beta-xcode6.1`) is deprecated
+    and will cease to be supported/provided by Travis [@jakirkham: citation needed],
+    so this change will have to happen at some point anyway.
+
+*   We won't be able to compile [clang
+    3.8/3.9](https://github.com/conda-forge/staged-recipes/pull/1481) without
+    this change.
+
+## Backward Compatibility
+
+*   The default deployment target for `xcode6.4` is macOS 10.11.
+    It would need to be forced to 10.9 (the lowest supported one
+    for that image) by hand.
+
+*   Even with this change, this would implicitly drop support for
+    macOS 10.7 and 10.8.
+
+## References
+
+*   [@jakirkham on implications](https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392)
+
+## Copyright
+
+All CFEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -15,13 +15,13 @@ Upgrade the default Travis image to `xcode6.4`.
 
 ## Implementation
 
-This is a one-line change to `.travis.yml`
+This is a one-line change to `.travis.yml`:
 
 ```
 osx_image: xcode6.4
 ```
 
-*   Adapt `conda smithy` so that it applies that edit on rerender
+*   Adapt `conda smithy` so that it applies that edit on rerender.
 *   Apply the change in the `staged-recipes` master branch.
 *   Rebuild all packages with this? (TBD? Opinions?)
 *   Suggest that all packages include the `toolchain` so that
@@ -48,7 +48,11 @@ osx_image: xcode6.4
 
 ## References
 
-*   [@jakirkham on implications](https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392)
+* [@jakirkham on implications][impl]
+* [Travis image support policy][travis]
+
+[impl](https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392)
+[travis][https://github.com/travis-ci/travis-ci/issues/6765#issuecomment-256703076]
 
 ## Copyright
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -24,13 +24,13 @@ Upgrade the default Travis image to `xcode6.4`.
 *   Rebuild all packages with this? (TBD? Opinions?)
 
     Likely not necessary given [C++ ABI Compatibility][cxxabi].
-*   Suggest that all new packages include the `toolchain` so that
-    the macOS 10.9 deployment target can be set.
+*   [`conda-forge-build-setup` will be modified](https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/46)
+    to automatically set the deployment target on OS/X builds.
 
-    Ideally, the correct setting of the deployment target would be verified by
-    CI, but the implementation of such a measure, while
-    [technically possible](http://stackoverflow.com/a/17148833),
-    is not part of this proposal.
+    As implemented in the linked PR, this requires `conda-build` version 2,
+    allowing the switch to that version and this change to be
+    implemented as part of the same process.
+    ([More discussion](https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6#discussion_r94984631))
 
 ## Rationale
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -48,8 +48,11 @@ Upgrade the default Travis image to `xcode6.4`.
 *   Multiple packages need this to move forward:
 
     *   [Apache Arrow](https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-254331475)
+        (Issues related to `rpath`/`@loader_path`)
     *   [libdynd](https://github.com/conda-forge/staged-recipes/pull/1051#issuecomment-233279062)
+        (Insufficient C++14 support in the current image)
     *   [clang 3.8/3.9](https://github.com/conda-forge/staged-recipes/pull/1481)
+        (Clang compilation crashes with the current image)
 
 ## Backward Compatibility
 

--- a/cfep-02.md
+++ b/cfep-02.md
@@ -6,7 +6,7 @@
 <tr><td> Created </td><td> Nov 8, 2016</td></tr>
 <tr><td> Updated </td><td> Nov 8, 2016</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6 </td></tr>
-<tr><td> Implementation </td><td> NA </td></tr>
+<tr><td> Implementation </td><td> (listed below) </td></tr>
 </table>
 
 ## Abstract
@@ -15,16 +15,16 @@ Upgrade the default Travis image to `xcode6.4`.
 
 ## Implementation
 
-This is a one-line change to `.travis.yml`:
-
-```
-osx_image: xcode6.4
-```
-
 *   Adapt `conda smithy` so that it applies that edit on rerender.
+    [One-liner change here](https://github.com/conda-forge/conda-smithy/blob/b1d1730c4b8c8dc849464b1b39569b0e61ec3130/conda_smithy/templates/travis.yml.tmpl#L12)
 *   Apply the change in the `staged-recipes` master branch.
+    [One-liner change here](https://github.com/conda-forge/staged-recipes/blob/3ce42e083cebe5f39eea82d069d5a94cb7719218/.travis.yml#L5)
+
+    [PR](https://github.com/conda-forge/staged-recipes/pull/1094)
 *   Rebuild all packages with this? (TBD? Opinions?)
-*   Suggest that all packages include the `toolchain` so that
+
+    Likely not necessary given [C++ ABI Compatibility][cxxabi].
+*   Suggest that all new packages include the `toolchain` so that
     the macOS 10.9 deployment target can be set.
 
 ## Rationale
@@ -33,13 +33,18 @@ osx_image: xcode6.4
     and will cease to be [supported/provided by Travis][travis],
     so this change will have to happen at some point anyway.
 
-*   We won't be able to compile [clang
-    3.8/3.9](https://github.com/conda-forge/staged-recipes/pull/1481) without
-    this change.
+    It will go away on January 21, 2017 according to the stated
+    plan in the linked comment.
+
+*   Multiple packages need this to move forward:
+
+    *   [Apache Arrow](https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-254331475)
+    *   [libdynd](https://github.com/conda-forge/staged-recipes/pull/1051#issuecomment-233279062)
+    *   [clang 3.8/3.9](https://github.com/conda-forge/staged-recipes/pull/1481)
 
 ## Backward Compatibility
 
-*   The default deployment target for `xcode6.4` is macOS 10.11.
+*   The default deployment target for `xcode6.4` is macOS 10.10.
     It would need to be forced to 10.9 (the lowest supported one
     for that image) by hand.
 
@@ -58,9 +63,11 @@ osx_image: xcode6.4
 * [Setting OS X deployment target](
 https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
 )
+* [Apple C++ ABI Compatibility][cxxabi]
 
 [impl]: https://github.com/conda-forge/conda-forge.github.io/issues/249#issuecomment-256207392
 [travis]: https://github.com/travis-ci/travis-ci/issues/6765#issuecomment-256703076
+[cxxabi]: https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/CppRuntimeEnv/Articles/CPPROverview.html
 
 ## Copyright
 


### PR DESCRIPTION
Here's a quick straw man for a CFEP to get the Travis image changed.

cc @jakirkham @conda-forge/core 