### PR TITLE
CFEP-11 Automated Closing of Excessively Old PRs on Staged Recipes

### DIFF
--- a/cfep-11.md
+++ b/cfep-11.md
@@ -2,7 +2,7 @@
 <table>
 <tr><td> Title </td><td> Simple staged-recipes Automation </td>
 <tr><td> Status </td><td> Draft  </td></tr>
-<tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt;</td></tr>
+<tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt; C.J. Wright &lt;&gt;</td></tr>
 <tr><td> Created </td><td> Nov 15, 2019</td></tr>
 <tr><td> Updated </td><td> Nov 15, 2019</td></tr>
 <tr><td> Discussion </td><td> NA </td></tr>
@@ -12,11 +12,11 @@
 ## Abstract
 
 While we are still debating CFEP-06 (https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/9), we can 
-implement a simple bot to close excessively old PRs on staged recipes. My proposal is to either make a bot or build a 
-CI cron-like job (in say CircleCI) to close PRs on staged-recipes that are more than 6 months old. It could run once 
-a week or so. The staged-recipes team is charged with both maintaining this bot and deciding on a nice and friendly message. 
+implement a simple bot to close excessively old PRs on staged recipes. Our proposal is to use the GitHub stale bot to 
+close PRs on staged-recipes that are more than 6 months old. The staged-recipes team is charged with both maintaining 
+this bot and deciding on a nice and friendly message. 
 
-As this CFEP is quite simple, I have omitted any other sections.  
+As this CFEP is quite simple, we have omitted any other sections.  
 
 ## Copyright
 

--- a/cfep-11.md
+++ b/cfep-11.md
@@ -2,7 +2,7 @@
 <table>
 <tr><td> Title </td><td> Automated Closing of Excessively Old PRs on Staged Recipes </td>
 <tr><td> Status </td><td> Draft  </td></tr>
-<tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt; C.J. Wright &lt;&gt;</td></tr>
+<tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt; Christopher J. "CJ" Wright &lt;cjwright4242@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Nov 15, 2019</td></tr>
 <tr><td> Updated </td><td> Nov 15, 2019</td></tr>
 <tr><td> Discussion </td><td> NA </td></tr>

--- a/cfep-11.md
+++ b/cfep-11.md
@@ -16,7 +16,12 @@ implement a simple bot to close excessively old PRs on staged recipes. Our prop
 close PRs on staged-recipes that are more than 6 months old. The staged-recipes team is charged with both maintaining 
 this bot and deciding on a nice and friendly message. 
 
-As this CFEP is quite simple, we have omitted any other sections.  
+## Motivation
+
+As of writing, the staged recipes repo has 289 PRs open from 2018 or earlier. Over time, the number of open PRs on 
+staged recipes has grown as PRs are abandoned but not closed. The staged recipes team is busy responding to new PRs 
+and so has not had time to clean out the old PRs. This CFEP adds a minimal level of automation in order to help the 
+team manage the growing number of open PRs.
 
 ## Copyright
 

--- a/cfep-11.md
+++ b/cfep-11.md
@@ -1,7 +1,7 @@
 
 <table>
 <tr><td> Title </td><td> Automated Closing of Excessively Old PRs on Staged Recipes </td>
-<tr><td> Status </td><td> Draft  </td></tr>
+<tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt; Christopher J. "CJ" Wright &lt;cjwright4242@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Nov 15, 2019</td></tr>
 <tr><td> Updated </td><td> Nov 15, 2019</td></tr>

--- a/cfep-11.md
+++ b/cfep-11.md
@@ -1,0 +1,23 @@
+
+<table>
+<tr><td> Title </td><td> Simple staged-recipes Automation </td>
+<tr><td> Status </td><td> Draft  </td></tr>
+<tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt;</td></tr>
+<tr><td> Created </td><td> Nov 15, 2019</td></tr>
+<tr><td> Updated </td><td> Nov 15, 2019</td></tr>
+<tr><td> Discussion </td><td> NA </td></tr>
+<tr><td> Implementation </td><td> NA </td></tr>
+</table>
+
+## Abstract
+
+While we are still debating CFEP-06 (https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/9), we can 
+implement a simple bot to close excessively old PRs on staged recipes. My proposal is to either make a bot or build a 
+CI cron-like job (in say CircleCI) to close PRs on staged-recipes that are more than 6 months old. It could run once 
+a week or so. The staged-recipes team is charged with both maintaining this bot and deciding on a nice and friendly message. 
+
+As this CFEP is quite simple, I have omitted any other sections.  
+
+## Copyright
+
+All CFEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cfep-11.md
+++ b/cfep-11.md
@@ -1,6 +1,6 @@
 
 <table>
-<tr><td> Title </td><td> Simple staged-recipes Automation </td>
+<tr><td> Title </td><td> Automated Closing of Excessively Old PRs on Staged Recipes </td>
 <tr><td> Status </td><td> Draft  </td></tr>
 <tr><td> Author(s) </td><td> Matthew R Becker &lt;becker.mr@gmail.com&gt; C.J. Wright &lt;&gt;</td></tr>
 <tr><td> Created </td><td> Nov 15, 2019</td></tr>


### PR DESCRIPTION
This CFEP proposes a simple form of staged-recipes automation that would nicely close excessively old PRs. 

It is related to #9, but is a lot simpler and so hopefully we can implement it now.