### PR TITLE
CFEP-18: Packaging static libraries

### DIFF
--- a/cfep-18.md
+++ b/cfep-18.md
@@ -27,7 +27,7 @@ In addition, our tooling (conda/conda-build/the bots) is also geared towards mai
 
 ## Rationale
 
-The current stack used to manage and consume conda-forge is tuned to deal with static linkages between packages.
+The current stack used to manage and consume conda-forge is tuned to deal with dynamic linkage between packages.
 As long as the solver can find a solution, updating a package version is simply updating the package itself, all other packages can stay untouched in the installations as long as they are compatible with the new version.
 If we would use static instead of shared linkage, we would need to rebuild the packages depending on that library.
 

--- a/cfep-18.md
+++ b/cfep-18.md
@@ -1,0 +1,79 @@
+
+<table>
+<tr><td> Title </td><td> Packaging static libraries </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Uwe L. Korn &lt;cfep@uwekorn.com&gt;</td></tr>
+<tr><td> Created </td><td> Jun 24, 2020</td></tr>
+<tr><td> Updated </td><td> Jun 24, 2020</td></tr>
+<tr><td> Discussion </td><td> NA </td></tr>
+<tr><td> Implementation </td><td> NA </td></tr>
+</table>
+
+## Abstract
+
+This CFEP proposes a policy on how to package static libraries / archives.
+These should be separated out into packages that are not installed in a default user setup.
+In general, we prefer our packages to work completely without static linkage between different packages but are aware that static archives are sometimes needed / useful.
+
+This CFEP excludes languages like Rust, Haskell, Go where binaries are always statically linked.
+The mentioned downsides apply there too but there isn't the option of using dynamic linkage.
+
+## Motivation
+
+At the moment, most binary packages that include libraries only ship their shared version.
+Some packages though also include the static version or only ship the static version.
+At runtime the static archives are not needed and thus are wasted space to the end user.
+In addition, our tooling (conda/conda-build/the bots) is also geared towards maintaining a set of dynamically linked packages.
+
+## Rationale
+
+The current stack used to manage and consume conda-forge is tuned to deal with static linkages between packages.
+As long as the solver can find a solution, updating a package version is simply updating the package itself, all other packages can stay untouched in the installations as long as they are compatible with the new version.
+If we would use static instead of shared linkage, we would need to rebuild the packages depending on that library.
+
+Rebuilding packages that depend on a library in the shared linkage setting are limited to the direct dependencies if there was an ABI breakage.
+If there was no ABI breakage, there is also no need to rebuild any downstream package.
+Users can simply update to the new version.
+
+Rebuilding packages with static linkage is more complicated as the symbols of the library are copied into every binary that uses the library.
+Thus there we would not only need to rebuild the packages that directly on the library but all the whole set of downstream packages that also have an indirect linkage as they also may contain copies of the symbols.
+As the symbols are copied, we would not even need to do these rebuilds for ABI / version changes but for every new build of the packaged library.
+
+As an additional complication, you also need to include the license of the library of the library in every package that includes symbols of a static library if the license of the library requires it.
+This means that executables that are statically linked also need to include the license headers of most of their libraries.
+
+Using dynamic linkage also has the benefit of a smaller disk usage even when the static archives are not installed.
+As we will have the symbols of a library copied into every binary that uses a library.
+In the dynamic setting, the symbols would only exist once on disk, inside the shared object.
+
+Not only does dynamic linkage reduce the storage requirements on disk but it also reduces the memory usage when several processes use the same library.
+Depending on the operation system, the symbols are then only loaded once into memory and shared between the processes.
+
+Build static archives (in separated packages) is still useful for some non-common workflows.
+These don't represent the majority of uses of our packages but can profit a lot from our using our existing infrastructure:
+
+* Building static binaries that can be shipped as a single executable to ease installation, e.g. `micromamba`
+* Building Python wheels for Windows: Wheels that include binary code link all their static libraries into their Python module and can profit from conda-forge having static builds available (note that this also requires the wheels or the user to separate supply the VC runtime conda-forge uses).
+
+* static binaries for linux that are shipped as a single file
+* windows python wheels
+
+
+## Implementation
+
+To implement the CFEP, we would remove static libraries from existing packages in new builds.
+Quite often static libraries where included by default without the need for them or just because they are the default output.
+They aren't is most cases not used / needed.
+
+If the static libraries are needed though, they should be added as a separate output with a `-static` suffix, see https://github.com/conda-forge/krb5-feedstock/pull/23/files .
+
+Packages that statically link a dependency need to take care that they include the license file of all dependencies that require it.
+
+## Reference
+
+Most distributions explicitly forbid the packaging of static libraries or require them to be in non-default / suffixed packages.
+The guide lines of [Debian](https://wiki.debian.org/StaticLinking) and [OpenSUSE](https://en.opensuse.org/openSUSE:Shared_library_packaging_policy) are the most informatives of them.
+
+## Copyright
+
+All CFEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cfep-18.md
+++ b/cfep-18.md
@@ -37,26 +37,26 @@ Users can simply update to the new version.
 
 Rebuilding packages with static linkage is more complicated as the symbols of the library are copied into every binary that uses the library.
 Thus there we would not only need to rebuild the packages that directly on the library but all the whole set of downstream packages that also have an indirect linkage as they also may contain copies of the symbols.
-As the symbols are copied, we would not even need to do these rebuilds for ABI / version changes but for every new build of the packaged library.
+As the symbols are copied, we would not only need to do these rebuilds for ABI / version changes but for every new build of the packaged library.
 
-As an additional complication, you also need to include the license of the library of the library in every package that includes symbols of a static library if the license of the library requires it.
+As an additional complication, you also need to include the license of the library in every package that includes symbols of a static library if the license of the library requires it.
 This means that executables that are statically linked also need to include the license headers of most of their libraries.
 
-Using dynamic linkage also has the benefit of a smaller disk usage even when the static archives are not installed.
-As we will have the symbols of a library copied into every binary that uses a library.
+Using dynamic linkage also has the benefit of a smaller disk usage even when the static archives are not installed, 
+as we will have the symbols of a library copied into every binary that uses a library.
 In the dynamic setting, the symbols would only exist once on disk, inside the shared object.
 
 Not only does dynamic linkage reduce the storage requirements on disk but it also reduces the memory usage when several processes use the same library.
 Depending on the operation system, the symbols are then only loaded once into memory and shared between the processes.
 
-Build static archives (in separated packages) is still useful for some non-common workflows.
-These don't represent the majority of uses of our packages but can profit a lot from our using our existing infrastructure:
+Building static archives (in separated packages) is still useful for some non-common workflows.
+These don't represent the majority of uses of our packages but can profit a lot from our using our existing infrastructure.
 
 ## Implementation
 
 To implement the CFEP, we would remove static libraries from existing packages in new builds.
-Quite often static libraries where included by default without the need for them or just because they are the default output.
-They aren't is most cases not used / needed.
+Quite often static libraries were included by default without the need for them or just because they are the default output.
+They are in most cases not used/needed.
 
 If the static libraries are needed though, they should be added as a separate output with a `-static` suffix, see https://github.com/conda-forge/krb5-feedstock/pull/23/files .
 


### PR DESCRIPTION
At the moment, most binary packages that include libraries only ship their shared version.
Some packages though also include the static version or only ship the static version.
At runtime the static archives are not needed and thus are wasted space to the end user.
In addition, our tooling (conda/conda-build/the bots) is also geared towards maintaining a set of dynamically linked packages.

This CFEP should serve as a document to make it clearer how to deal with static libraries.