### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @conda-forge/core


### PR DESCRIPTION
This should allow cfep to automatically assign core as a reviewer for everything landing in this repo, though it seems that you can only select 10 assignees as reviewers?