### PR TITLE
Propose CFEP-21 license packages for static/header libraries

### DIFF
--- a/cfep-21.md
+++ b/cfep-21.md
@@ -1,0 +1,52 @@
+
+<table>
+<tr><td> Title </td><td> Export license packages for static and header-only libraries </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Daniel Ching &lt;carterbox@users.noreply.github.com&gt;</td></tr>
+<tr><td> Created </td><td> Jul 9, 2022</td></tr>
+<tr><td> Updated </td><td> Jul 9, 2022</td></tr>
+<tr><td> Discussion </td><td> NA </td></tr>
+<tr><td> Implementation </td><td> NA </td></tr>
+</table>
+
+## Abstract
+
+This CFEP proposes that header-only and static libraries and should be required
+to run_export an empty package (containing their license) called "{{ name
+}}-license" in order to ensure/automate attribution and to satisfy the license
+requirements.
+
+## Specification
+
+Header-only or static library packages should include an output called
+"{{ name }}-license" which is added as a run_export for the library.
+
+## Motivation
+
+Attribution for header-only and static libraries on conda-forge is not well
+enforced because unlike shared libraries which are also required to be
+installed again at runtime (with license included), these libraries need manual
+intervention to ensure that the license of the header-only or static library is
+concatenated to the license metadata of the downstream library which uses it.
+This should obviously be done and is easy to notice for static libraries (whose
+names end in "-static"), but for header-only libraries it is less obvious
+because the name of the library does not obviously mark the library as
+header-only.
+
+Libraries like Eigen and Pybind11 are commonly used, but probably not
+attributed beyond their mention in the host section of the recipe. Mention in
+the requirements section of a recipe probably does not meet the
+licensing/attribution requirements.
+
+## Rationale
+
+run_exports is the obvious way to deliver the license information into the
+environment of downstream packages; this is already how the license information
+is included for dynamically linked libraries.
+
+"{{ name }}-license" matches the exisiting naming scheme for "{{ name }}-static"
+"{{ name }}-includes".
+
+## Copyright
+
+All CFEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cfep-21.md
+++ b/cfep-21.md
@@ -1,10 +1,10 @@
 
 <table>
 <tr><td> Title </td><td> Export license packages for static and header-only libraries </td>
-<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Status </td><td> Proposed </td></tr>
 <tr><td> Author(s) </td><td> Daniel Ching &lt;carterbox@users.noreply.github.com&gt;</td></tr>
 <tr><td> Created </td><td> Jul 9, 2022</td></tr>
-<tr><td> Updated </td><td> Jul 9, 2022</td></tr>
+<tr><td> Updated </td><td> Jul 25, 2022</td></tr>
 <tr><td> Discussion </td><td> NA </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>

--- a/cfep-21.md
+++ b/cfep-21.md
@@ -47,6 +47,14 @@ is included for dynamically linked libraries.
 "{{ name }}-license" matches the exisiting naming scheme for "{{ name }}-static"
 "{{ name }}-includes".
 
+## FAQ
+
+### How does this affect current builds of packages?
+
+It doesn't. The changes will slowly be implemented over time as packages and their
+downstream packages are rebuilt with regular releases. Migrations are a tool
+that could be used to if desired for certain packages.
+
 ## Copyright
 
 All CFEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cfep-21.md
+++ b/cfep-21.md
@@ -11,7 +11,7 @@
 
 ## Abstract
 
-This CFEP proposes that header-only and static libraries and should be required
+This CFEP proposes that header-only and static libraries should be required
 to run_export an empty package (containing their license) called "{{ name
 }}-license" in order to ensure/automate attribution and to satisfy the license
 requirements.


### PR DESCRIPTION
@hmaarrfk, mentioned this in a discussion today, and every so often I wonder about whether licenses for header-only libraries are being satisfied. I wrote something up to see if we can make this official policy.