### PR TITLE
Update CFEP 3's status to accepted

### DIFF
--- a/cfep-03.md
+++ b/cfep-03.md
@@ -1,11 +1,11 @@
 
 <table>
 <tr><td> Title </td><td> Providing manually uploaded builds on the conda-forge anaconda channel</td>
-<tr><td> Status </td><td> Proposed </td></tr>
+<tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Hadrien Mary &lt;hadrien.mary@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Sep 27, 2016</td></tr>
 <tr><td> Updated </td><td> Oct 17, 2019</td></tr>
-<tr><td> Updated </td><td> Feb 21, 2022 (hmaarrfk) </td></tr>
+<tr><td> Updated </td><td> Jan 6, 2023 (jakirkham) </td></tr>
 <tr><td> Discussion </td><td> NA </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>


### PR DESCRIPTION
We called for a vote on Nov 20, 2019 for CFEP 3. At the time there were [18 core members]( https://github.com/conda-forge/conda-forge.github.io/blob/77eb518767df9f9a730b3409dd787f087bb9af8b/src/core.csv ). We got 11 approves by the end of the voting period, which was ~61%. So over the 60% threshhold. We merged the PR, but didn't update the status to "Accepted". This makes that change for clarity.