### PR TITLE
cfep-03: Fix label typo and add command to upload package under cfep03 label

### DIFF
--- a/cfep-03.md
+++ b/cfep-03.md
@@ -6,6 +6,7 @@
 <tr><td> Created </td><td> Sep 27, 2016</td></tr>
 <tr><td> Updated </td><td> Oct 17, 2019</td></tr>
 <tr><td> Updated </td><td> Jan 6, 2023 (jakirkham) </td></tr>
+<tr><td> Updated </td><td> Sep 18, 2024 (traversaro) </td></tr>
 <tr><td> Discussion </td><td> NA </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
@@ -34,8 +35,8 @@ The protocol we propose is:
 - Core members can then review the logs and test packages.
 
 - To upload the packages to the conda-forge channel, core members are provided with two options:
-    1. Upload the package manually with the appropriate `anaconda upload` command.
-    2. Copy the package over from the delegate's channel. If the delegate has provided a unique tag, such as `cfep-03`, the following commands can be used to copy over the packages
+    1. Upload the package manually with the appropriate `anaconda upload` command. A possible command to upload a given package-x.y.z.conda file is `ANACONDA_API_TOKEN=<insert_your_anaconda_org_token> anaconda upload --label cfep03 package-x.y.z.conda`
+    2. Copy the package over from the delegate's channel. If the delegate has provided a unique tag, such as `cfep03`, the following commands can be used to copy over the packages
 ```bash
 anaconda copy --from-label cfep03 --to-label main --to-owner conda-forge DELEGATES_CHANNEL/PACKAGE_NAME/PACKAGE_VERSION
 ```


### PR DESCRIPTION
Not sure what is the process for this, but today I did my first `cfep03` build in https://github.com/conda-forge/qt-main-feedstock/pull/288#issuecomment-2358160682 and I did not have a lot of experience with labels, so having a ready to use command would have been helpful. Furthermore, there was a typo in the label name in a sentence.

fyi @hmaarrfk


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
